### PR TITLE
Fix ActionNode keep resetting to equal

### DIFF
--- a/Scripts/SidePanelNodes/ActionNodePanel.gd
+++ b/Scripts/SidePanelNodes/ActionNodePanel.gd
@@ -68,6 +68,14 @@ func _from_dict(dict: Dictionary):
 						number_edit.value = value
 					"String":
 						string_edit.text = value
+					
+			var operator_str: String = action.get("Operator")
+			var operator_id := 0
+			for op in operator_drop_node.item_count:
+				if operator_drop_node.get_item_text(op) == operator_str:
+					operator_id = op
+			operator_drop_node.select(operator_id)
+
 		"ActionCustom":
 			action_drop_node.select(2)
 			match action.get("CustomType"):


### PR DESCRIPTION
This fix issuie:

1. Crate Int variable in RootNode
2. Crate ActionNode
3. Set ActionNode mode to VariableAction
4. Set Int to be modfied Variable
5. Try to set operator to anytihng other than `=`
6. Exit SidePanel of this ActionNode
7. Try Edit ActionNode - you will notice that operator resest back to `=`

Also if you load json with ActionNode/VariableAction all operators will be rested to `=`

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Fix the issue where the operator in ActionNode resets to '=' upon exiting and re-editing the SidePanel, and ensure that loading JSON with ActionNode/VariableAction retains the correct operator.

Bug Fixes:
- Fix issue where the operator in ActionNode resets to '=' when exiting and re-editing the SidePanel.
- Ensure that loading JSON with ActionNode/VariableAction retains the correct operator instead of resetting to '='.

<!-- Generated by sourcery-ai[bot]: end summary -->