### PR TITLE
Prevent group delete at the same time as select or when panel is up

### DIFF
--- a/Scripts/MonologueGraphEdit.gd
+++ b/Scripts/MonologueGraphEdit.gd
@@ -26,14 +26,15 @@ func _ready():
 
 
 func _input(event):
-	if event.is_action_pressed("ui_graph_delete"):
-		if control_node.get_current_graph_edit() == self and selected_nodes:
-			var selected_copy = selected_nodes.duplicate()
-			var delete_history = DeleteNodeHistory.new(self, selected_copy)
-			undo_redo.create_action("Delete %s" % str(selected_copy))
-			undo_redo.add_prepared_history(delete_history)
-			undo_redo.commit_action()
-			return
+	if event.is_action_pressed("ui_graph_delete") and \
+			!control_node.side_panel_node.visible and !active_graphnode and \
+			control_node.get_current_graph_edit() == self and selected_nodes:
+		var selected_copy = selected_nodes.duplicate()
+		var delete_history = DeleteNodeHistory.new(self, selected_copy)
+		undo_redo.create_action("Delete %s" % str(selected_copy))
+		undo_redo.add_prepared_history(delete_history)
+		undo_redo.commit_action()
+		return
 	
 	var is_mouse_clicked = Input.is_action_pressed("Select")
 	var is_mouse_moving = event is InputEventMouseMotion

--- a/Scripts/SidePanelNodes/SidePanelNodeDetails.gd
+++ b/Scripts/SidePanelNodes/SidePanelNodeDetails.gd
@@ -36,11 +36,12 @@ func on_graph_node_selected(node: MonologueGraphNode, bypass: bool = false):
 	if not bypass:
 		var graph_edit = control_node.get_current_graph_edit()
 		await get_tree().create_timer(0.1).timeout
-		if graph_edit.moving_mode or graph_edit.selected_nodes.size() > 1:
+		if is_instance_valid(node) and not graph_edit.moving_mode and \
+				graph_edit.selected_nodes.size() == 1:
+			graph_edit.active_graphnode = node
+		else:
 			graph_edit.active_graphnode = null
 			return
-		else:
-			graph_edit.active_graphnode = node
 	
 	line_edit_id.text = node.id
 	var new_panel = null


### PR DESCRIPTION
This bug was introduced by me in #19, it allowed the user to delete nodes with the `Delete` key while the panel is open. This causes crashes because the node is no longer there while editing properties, as the `Delete` key is used in text-editing as well, but will delete the node at the same time. There was also a funny way to crash the program by selecting the node and deleting it within await 0.1 seconds, so the node is no longer there when the panel wants to open.

This PR fixes the 0.1 second crash window, and prevent crashes associated with triggering the Delete hotkey while panel is open. You can still delete nodes with the 'X' button while the panel is open, this works fine and doesn't crash the program, the problem is with the delete timing with the `Delete` key.

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Prevent node deletion when the side panel is open or when a node is selected and deleted within a short time frame to fix crashes.

Bug Fixes:
- Fix crashes caused by deleting nodes with the Delete key while the side panel is open by adding checks to prevent deletion in this state.
- Resolve a crash issue that occurred when selecting and deleting a node within 0.1 seconds, ensuring the node is valid before setting it as active.

<!-- Generated by sourcery-ai[bot]: end summary -->