### PR TITLE
Set minimum size for end path icon

### DIFF
--- a/Objects/GraphNodes/EndPathNode.tscn
+++ b/Objects/GraphNodes/EndPathNode.tscn
@@ -43,6 +43,7 @@ slot/0/draw_stylebox = false
 script = ExtResource("1_vdup8")
 
 [node name="TextureRect" type="TextureRect" parent="."]
+custom_minimum_size = Vector2(87, 87)
 layout_mode = 2
 size_flags_vertical = 3
 texture = ExtResource("2_nabb1")


### PR DESCRIPTION
Super simple, one-line fix for #14. Bug was caused by `size.y = 0` in MonologueGraphNode `_common_update()` which is supposed to shrink y content, but the end path node icon does not have a minimum size, so it shrinks to 0. The fix is to set a minimum size, that's it.